### PR TITLE
Update slowloris.py

### DIFF
--- a/slowloris.py
+++ b/slowloris.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import argparse
 import logging
 import random


### PR DESCRIPTION
Updated shebang to Google coding standards. The shebang formally pointed to "python", which usually refers to python2.7 on Linux systems. Now it uses "env" to find the Python3 interpreter.