### PR TITLE
Now slowloris works with untrusted/invalid certificate.

### DIFF
--- a/slowloris.py
+++ b/slowloris.py
@@ -159,6 +159,8 @@ def init_socket(ip):
 
     if args.https:
         ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
         s = ctx.wrap_socket(s, server_hostname=args.host)
 
     s.connect((ip, args.port))


### PR DESCRIPTION
If remote server use invalid certificate or unsigned by trusted CA slowloris fails silently and create zero socets. Now it's fixed.  