### PR TITLE
Fix user_agent array

### DIFF
--- a/slowloris.py
+++ b/slowloris.py
@@ -131,7 +131,7 @@ user_agents = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Safari/602.1.50",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393",
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36",
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36",
     "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36",


### PR DESCRIPTION
This PR should fix the user_agent array.

# Motivation
I wrote Slowloris with a different language for self-learning purposes and noticed that the user_agent array raised errors.

I confirmed that the user_agent array lacked one comma.
But it only concatenates a UserAgent string sometimes like below and does not affect Slowloris's main actions.
 
![Снимок экрана_2022-11-21_03-12-17](https://user-images.githubusercontent.com/100127291/202934305-c1b306e2-210d-4fe1-a72f-2c7dae8bbae8.png)

So if you think it is not important. Please ignore my PR.

Last but not least, thank you for your great work!